### PR TITLE
Добавить composer audit в CI для проверки зависимостей

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Security audit
+        run: composer audit --locked
+
       - name: Debug PHP
         run: php -v && php -m
 


### PR DESCRIPTION
### Motivation
- Добавить автоматическую проверку уязвимостей зависимостей в CI, чтобы выявлять и блокировать известные проблемы в пакетах сразу после `composer install --no-interaction --prefer-dist`.

### Description
- Обновлён файл `.github/workflows/ci.yml`: добавлен шаг `Security audit`, выполняющий `composer audit --locked`, расположенный после установки зависимостей.

### Testing
- Изменение относится только к workflow; локальных автоматизированных тестов не запускалось, но на CI при PR/push будет выполнен новый шаг `composer audit --locked`, при этом существующие проверки `phpstan`, `bin/console doctrine:schema:validate` и `vendor/bin/phpunit --testsuite=unit,integration,e2e --coverage-text` остаются в пайплайне.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695b70a6d88322ac9db9f8c2c35992)